### PR TITLE
Adds patches for emojivoto services

### DIFF
--- a/emojivoto-example/kustomize/kustomization.yaml
+++ b/emojivoto-example/kustomize/kustomization.yaml
@@ -12,3 +12,15 @@ commonAnnotations:
 # Emojivoto resources (namespace, services, deployments, etc)
 resources:
   - github.com/BuoyantIO/emojivoto/kustomize/deployment
+
+patches:
+  - path: patches/emoji-svc.yaml
+    target:
+      version: v1
+      kind: Service
+      name: emoji-svc
+  - path: patches/voting-svc.yaml
+    target:
+      version: v1
+      kind: Service
+      name: voting-svc

--- a/emojivoto-example/kustomize/patches/emoji-svc.yaml
+++ b/emojivoto-example/kustomize/patches/emoji-svc.yaml
@@ -1,0 +1,4 @@
+- op: add
+  path: /metadata/labels
+  value: 
+    app: emoji-svc

--- a/emojivoto-example/kustomize/patches/voting-svc.yaml
+++ b/emojivoto-example/kustomize/patches/voting-svc.yaml
@@ -1,0 +1,4 @@
+- op: add
+  path: /metadata/labels
+  value: 
+    app: voting-svc


### PR DESCRIPTION
We need to add labels to some emojivoto sample app services.
This sample app will be used in the Starter Kit (https://github.com/digitalocean/Kubernetes-Starter-Kit-Developers) for demonstration purposes.
Adding labels to services will ease configuring of additionalServiceMonitors for Prometheus in chapter 4 of the Starter Kit.