### PR TITLE
Removes dev tag from development environment

### DIFF
--- a/microservices-demo/kustomize/dev/kustomization.yaml
+++ b/microservices-demo/kustomize/dev/kustomization.yaml
@@ -12,28 +12,28 @@ resources:
 images:
   - name: cartservice
     newName: registry.digitalocean.com/microservices-demo/cartservice
-    newTag: 1.0.0-dev
+    newTag: 1.0.0
   - name: checkoutservice
     newName: registry.digitalocean.com/microservices-demo/checkoutservice
-    newTag: 1.0.0-dev
+    newTag: 1.0.0
   - name: currencyservice
     newName: registry.digitalocean.com/microservices-demo/currencyservice
-    newTag: 1.0.0-dev
+    newTag: 1.0.0
   - name: emailservice
     newName: registry.digitalocean.com/microservices-demo/emailservice
-    newTag: 1.0.0-dev
+    newTag: 1.0.0
   - name: frontend
     newName: registry.digitalocean.com/microservices-demo/frontend
-    newTag: 1.0.0-dev
+    newTag: 1.0.0
   - name: paymentservice
     newName: registry.digitalocean.com/microservices-demo/paymentservice
-    newTag: 1.0.0-dev
+    newTag: 1.0.0
   - name: productcatalogservice
     newName: registry.digitalocean.com/microservices-demo/productcatalogservice
-    newTag: 1.0.0-dev
+    newTag: 1.0.0
   - name: recommendationservice
     newName: registry.digitalocean.com/microservices-demo/recommendationservice
-    newTag: 1.0.0-dev
+    newTag: 1.0.0
   - name: shippingservice
     newName: registry.digitalocean.com/microservices-demo/shippingservice
-    newTag: 1.0.0-dev
+    newTag: 1.0.0


### PR DESCRIPTION
Removes the "-dev" suffix from the image tag on development environment. We want to have consistency for the initial release name.